### PR TITLE
cli: introduce clap as cli parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tonic = "0.9"
 prost = "0.11"
 nostr = "0.22"
 url = "2.4.0"
+clap = { version = "4.3.8", features = ["derive"] }
 
 [build-dependencies]
 tonic-build = "0.9"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Connecting to a BOLT8 peer on local.
 ```
 ./civkitd (civtkid #1)
 
-./civkitd /* noise port */ 60001 /* nostr port */ 60011 cli_port 60021 (civkitd #2)
+./civkitd 
+./civkitd --noise-port 60001 --nostr-port 60011 --cli-port 60021 (civkitd #2)
 
 ./civkit-cli connectpeer 60001
 


### PR DESCRIPTION
This PR introduces [clap](https://docs.rs/clap/latest/clap/) as a dependency to enhance the cli parsing at the server (`civkitd`) and client (`civkit-cli`). This simplifies the logic for parsing and handling the different commands and also provides nice help-text capabilities, making it easier for someone to understand the current features of the civkit-node.

Preview of `./civkitd --help` command:
```
Usage: civkitd [OPTIONS]

Options:
  -p, --noise-port <NOISE_PORT>  The port to listen for BOLT8 peers [default: 50011]
  -n, --nostr-port <NOSTR_PORT>  Nostr relay port [default: 50021]
  -c, --cli-port <CLI_PORT>      The port to listen for CLI connections [default: 50031]
  -h, --help                     Print help
```
 
Preview of `./civkit-cli --help` command:
```
Usage: civkit-cli [OPTIONS] <COMMAND>

Commands:
  ping               Send a ping message
  shutdown           Shutdown the connected CivKit node
  publishtextnote    Send a demo NIP-01 EVENT kind 1 to all the connected clients
  listclient         List information about connected clients [TODO]
  listsubscriptions  List information about subscriptions [TODO]
  connectpeer        Connect to a BOLT8 peer on local port
  disconnectclient   Disconnect from a client [TODO]
  publishnotice      Send a demo NIP-01 NOTICE to all the connected clients
  help               Print this message or the help of the given subcommand(s)

Options:
  -p, --port <PORT>  The port of the connected server [default: 50031]
  -h, --help         Print help
```