### PR TITLE
Move Noise port to LN one

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Civkit sample startup successful. Enter "help" to view available commands.
 
 /* On logs of civkitd  */
 [CIVKITD] - INIT: CivKit node starting up...
-[CIVKITD] - INIT: noise port 50011 nostr port 50021 cli_port 50031
+[CIVKITD] - INIT: noise port 9735 nostr port 50021 cli_port 50031
 [CIVKITD] - NET: ready to listen tcp connection for clients !
 [CIVKITD] - NET: receive a tcp connection !
 [CIVKITD] - NET: incoming tcp Connection from :[::1]:50422
@@ -94,7 +94,7 @@ Connecting to a BOLT8 peer on local.
 
 /* On logs of civkitd #1 */
 [CIVKITD] - INIT: CivKit node starting up...
-[CIVKITD] - INIT: noise port 50011 nostr port 50021 cli_port 50031
+[CIVKITD] - INIT: noise port 9735 nostr port 50021 cli_port 50031
 [CIVKITD] - NET: ready to listen tcp connection for clients !
 [CIVKITD] - CONTROL: sending port to noise gateway !
 [CIVKITD] - NOISE: opening outgoing noise connection!

--- a/src/server.rs
+++ b/src/server.rs
@@ -167,7 +167,7 @@ impl BoardCtrl for ServiceManager {
 #[derive(Parser, Debug)]
 struct Cli {
 	/// The port to listen for BOLT8 peers
-	#[clap(long, short = 'p', default_value = "50011")]
+	#[clap(long, short = 'p', default_value = "9735")]
 	noise_port: String,
 	/// Nostr relay port
 	#[clap(short, long, default_value = "50021")]


### PR DESCRIPTION
Following BOLT1, the canonical TCP port is `9735` (mainet), so this PR updates to the correct port.

This enable to benefit from the Lightning network of peers for future onions propagations and therefore have a bigger anonymity set. 