### PR TITLE
Add new Nostr event `order` of kind `32_500` + `publishoffer` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tokio-tungstenite = "0.19.0"
 bitcoin = "0.29.0"
 tonic = "0.9"
 prost = "0.11"
-nostr = "0.22"
+nostr = { git = "https://github.com/civkit/nostr.git", branch = "civkit-branch" }
 url = "2.4.0"
 clap = { version = "4.3.8", features = ["derive"] }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,10 +8,20 @@
 // licenses.
 
 use boardctrl::board_ctrl_client::BoardCtrlClient;
-use boardctrl::{PingRequest, PongRequest, ShutdownRequest, ShutdownReply, SendNote, ReceivedNote, ListClientRequest, ListSubscriptionRequest, PeerConnectionRequest, DisconnectClientRequest, SendNotice};
+use boardctrl::{PingRequest, PongRequest, ShutdownRequest, ShutdownReply, SendNote, ReceivedNote, ListClientRequest, ListSubscriptionRequest, PeerConnectionRequest, DisconnectClientRequest, SendNotice, SendOffer};
 
 use std::env;
 use std::process;
+
+use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use bitcoin::KeyPair;
+use lightning::offers::offer::{Offer, OfferBuilder, Quantity};
+
+use lightning::util::ser::Writeable;
+
+use std::time::SystemTime;
+
+use tokio::time::Duration;
 
 use clap::{Parser, Subcommand};
 
@@ -50,6 +60,11 @@ enum Command {
 	Disconnectclient,
 	/// Send a demo NIP-01 NOTICE to all the connected clients
 	Publishnotice,
+	/// Send a BOLT12 offers to all the connected clients
+	Publishoffer {
+		/// The BOLT12 offer to be announced
+		offer: String,
+	},
 }
 
 #[tokio::main]
@@ -117,6 +132,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 			});
 
 			let response = client.publish_notice(request).await?;
+		}
+		Command::Publishoffer { offer } => {
+			//TODO: take real offer from input
+			let secp_ctx = Secp256k1::new();
+			let keys = KeyPair::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42;32]).unwrap());
+			let pubkey = PublicKey::from(keys);
+
+			let expiration = SystemTime::now() + Duration::from_secs(24 * 60 * 60);
+
+			let offer = OfferBuilder::new("naira".to_string(), pubkey)
+				.amount_msats(10_000)
+				.supported_quantity(Quantity::Unbounded)
+				.absolute_expiry(expiration.duration_since(SystemTime::UNIX_EPOCH).unwrap())
+				.issuer("Foo Bar".to_string())
+				.build().unwrap();
+			let mut bytes = Vec::new();
+			offer.write(&mut bytes).unwrap();
+			let request = tonic::Request::new(SendOffer {
+				offer: bytes,
+			});
+
+			let response = client.publish_offer(request).await?;
 		}
 	}
 	Ok(())

--- a/src/clienthandler.rs
+++ b/src/clienthandler.rs
@@ -245,6 +245,9 @@ impl ClientHandler {
 								Err(_) => { println!("[CIVKITD] - NOSTR: Error inter thread sending notice"); },
 							}
 						},
+						ClientEvents::Offer { } => {
+							let random_id = SubscriptionId::generate();
+						},
 						_ => {}
 					}
 				}

--- a/src/clienthandler.rs
+++ b/src/clienthandler.rs
@@ -245,8 +245,14 @@ impl ClientHandler {
 								Err(_) => { println!("[CIVKITD] - NOSTR: Error inter thread sending notice"); },
 							}
 						},
-						ClientEvents::Offer { } => {
+						ClientEvents::OrderNote { ref order } => {
 							let random_id = SubscriptionId::generate();
+							let relay_message = RelayMessage::new_event(random_id, order.clone());
+							let serialized_message = relay_message.as_json();
+							match outgoing_send.send(serialized_message.into_bytes()) {
+								Ok(_) => {},
+								Err(_) => { println!("[CIVKITD] - NOSTR: Error inter thread sending order"); }
+							}
 						},
 						_ => {}
 					}

--- a/src/events.rs
+++ b/src/events.rs
@@ -22,7 +22,7 @@ pub enum ClientEvents {
 	Server { cmd: ServerCmd },
 	EndOfStoredEvents { client_id: u64, sub_id: SubscriptionId },
 	RelayNotice { message: String },
-	Offer { },
+	OrderNote { order: Event },
 	SubscribedEvent { client_id: u64, sub_id: SubscriptionId, event: Event },
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -22,6 +22,7 @@ pub enum ClientEvents {
 	Server { cmd: ServerCmd },
 	EndOfStoredEvents { client_id: u64, sub_id: SubscriptionId },
 	RelayNotice { message: String },
+	Offer { },
 	SubscribedEvent { client_id: u64, sub_id: SubscriptionId, event: Event },
 }
 

--- a/src/oniongateway.rs
+++ b/src/oniongateway.rs
@@ -45,7 +45,7 @@ impl OnionBox {
 		let logger = Arc::new(FakeLogger {});
 		let ignoring_message_handler = IgnoringMessageHandler {};
 
-		let onion_messenger = OnionMessenger::new(&keys_manager, &keys_manager_2, logger, &ignoring_message_handler);
+		//let onion_messenger = OnionMessenger::new(&keys_manager, &keys_manager_2, logger, &ignoring_message_handler);
 
 		OnionBox {
 			our_node_pubkey: pubkey,

--- a/src/proto/boardctrl.proto
+++ b/src/proto/boardctrl.proto
@@ -16,6 +16,7 @@ service BoardCtrl {
 	rpc DisconnectClient (DisconnectClientRequest) returns (DisconnectClientReply);
 	/* NIP 01 - from relay to client: NOTICE */
 	rpc PublishNotice (SendNotice) returns (ReceivedNotice);
+	rpc PublishOffer (SendOffer) returns (ReceivedOffer);
 }
 
 message PingRequest {
@@ -96,4 +97,11 @@ message SendNotice {
 }
 
 message ReceivedNotice {
+}
+
+message SendOffer {
+	bytes offer = 1;
+}
+
+message ReceivedOffer {
 }

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -225,17 +225,18 @@ async fn poll_for_server_output(mut rx: futures_channel::mpsc::UnboundedReceiver
                 //println!("Received message {}", msg_json);
                 if let Ok(relay_msg) = RelayMessage::from_json(msg_json) {
                     match relay_msg {
-					RelayMessage::Event { subscription_id, event } => {
-                            //TODO: NIP 01: `EVENT` messages MUST be sent only with a subscriptionID related to a subscription previously initiated by the client (using the `REQ` message above)`
-                            println!("\n[EVENT] {}", event.content);
-                            print!("> ");
-                            io::stdout().flush().unwrap();
-					},
+			RelayMessage::Event { subscription_id, event } => {
+			    //TODO: NIP 01: `EVENT` messages MUST be sent only with a subscriptionID related to a subscription previously initiated by the client (using the `REQ` message above)`
+			    let display_board_order = if event.kind == Kind::Order { true } else { false };
+			    println!("\n[EVENT] {}  {}", if display_board_order { "new trade offer: " } else { "" }, event.content);
+			    print!("> ");
+			    io::stdout().flush().unwrap();
+			},
                         RelayMessage::Notice { message } => {
                             println!("\n[NOTICE] {}", message);
                             print!("> ");
                             io::stdout().flush().unwrap();
-					},
+			},
                         RelayMessage::EndOfStoredEvents(sub_id) => {
                             println!("\n[EOSE] {}", sub_id);
                             print!("> ");
@@ -243,7 +244,7 @@ async fn poll_for_server_output(mut rx: futures_channel::mpsc::UnboundedReceiver
 					},
 					_ => { println!("Unknown server message"); }
                         }
-			} else { println!("RelayMessage deserialization failure"); }
+		} else { println!("RelayMessage deserialization failure"); }
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -179,6 +179,19 @@ impl BoardCtrl for ServiceManager {
 
 		Ok(Response::new(boardctrl::ReceivedNotice {}))
 	}
+
+	async fn publish_offer(&self, request: Request<boardctrl::SendOffer>) -> Result<Response<boardctrl::ReceivedOffer>, Status> {
+		let offer_message = request.into_inner().offer;
+
+		let service_keys = Keys::generate();
+ 
+		{
+			let mut board_send_lock = self.service_events_send.lock().unwrap();
+			board_send_lock.send(ClientEvents::Offer { });
+		}
+
+		Ok(Response::new(boardctrl::ReceivedOffer {}))
+	}
 }
 
 #[derive(Parser, Debug)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,6 +23,8 @@ use civkit::oniongateway::OnionBox;
 
 use civkit::events::{ClientEvents, EventsProvider, ServerCmd};
 
+use lightning::offers::offer::Offer;
+
 use boardctrl::board_ctrl_server::{BoardCtrl, BoardCtrlServer};
 
 use clap::Parser;
@@ -184,10 +186,14 @@ impl BoardCtrl for ServiceManager {
 		let offer_message = request.into_inner().offer;
 
 		let service_keys = Keys::generate();
- 
-		{
-			let mut board_send_lock = self.service_events_send.lock().unwrap();
-			board_send_lock.send(ClientEvents::Offer { });
+
+		if let Ok(offer) = Offer::try_from(offer_message) {
+			let encoded_offer = offer.to_string();
+			if let Ok(kind32500_event) = EventBuilder::new_order_note(encoded_offer, &[]).to_event(&service_keys)
+			{
+				let mut board_send_lock = self.service_events_send.lock().unwrap();
+				board_send_lock.send(ClientEvents::OrderNote { order: kind32500_event });
+			}
 		}
 
 		Ok(Response::new(boardctrl::ReceivedOffer {}))


### PR DESCRIPTION
Building on top of #19, this add the relay logic to announce the offer under a new Nostr `order` event of kind `32_500`.

For the rational of of the kind range and more explanation, see NIP-XXX opened in the NIPs repository.

