### PR TITLE
add `listclients` functionality

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -37,8 +37,8 @@ enum Command {
 	Shutdown,
 	/// Send a demo NIP-01 EVENT kind 1 to all the connected clients
 	Publishtextnote,
-	/// List information about connected clients [TODO]
-	Listclient,
+	/// List information about connected clients
+	Listclients,
 	/// List information about subscriptions [TODO]
 	Listsubscriptions,
 	/// Connect to a BOLT8 peer on local port
@@ -83,12 +83,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 			println!("[CIVKIT-CLI] {}", response.into_inner().name);
 		}
-		Command::Listclient => {
+		Command::Listclients => {
 			let request = tonic::Request::new(ListClientRequest {});
 
 			let response = client.list_clients(request).await?;
 
-			println!("[CIVKIT-CLI] clients {}", response.into_inner().clients);
+			println!("[CIVKIT-CLI] clients {:#?}", response.into_inner().clients);
 		}
 		Command::Listsubscriptions => {
 			let request = tonic::Request::new(ListSubscriptionRequest {});

--- a/src/clienthandler.rs
+++ b/src/clienthandler.rs
@@ -340,7 +340,7 @@ impl ClientHandler {
 						match client_msg {
 							ClientMessage::Event(msg) => {
 								if let Some(nostr_client) = self.clients.get_mut(&id) {
-									if nostr_client.has_pubkey() {
+									if !nostr_client.has_pubkey() {
 										nostr_client.add_pubkey(msg.pubkey.clone());
 									}
 								}

--- a/src/clienthandler.rs
+++ b/src/clienthandler.rs
@@ -16,8 +16,7 @@ use bitcoin::secp256k1::Secp256k1;
 use nostr::{RelayMessage, Event, ClientMessage, SubscriptionId, Filter};
 use nostr::key::XOnlyPublicKey;
 
-use civkit::events;
-use civkit::events::{ClientEvents, EventsProvider, ServerCmd};
+use crate::events::{ClientEvents, EventsProvider, ServerCmd};
 
 use futures_util::{future, pin_mut, TryStreamExt, StreamExt, SinkExt};
 

--- a/src/clienthandler.rs
+++ b/src/clienthandler.rs
@@ -37,13 +37,14 @@ use tokio_tungstenite::tungstenite::Message;
 /// Max number of subscriptions by connected clients.
 const MAX_SUBSCRIPTIONS: u64 = 100;
 
-struct NostrClient {
+#[derive(Debug, Clone)]
+pub struct NostrClient {
 	//TODO: check we're using Schnorr not ECDSA
-	pubkey: Option<XOnlyPublicKey>,
-	client_id: u64,
-	associated_socket: SocketAddr,
+	pub pubkey: Option<XOnlyPublicKey>,
+	pub client_id: u64,
+	pub associated_socket: SocketAddr,
 
-	subscriptions: HashMap<u64, ()>,
+	pub subscriptions: HashMap<u64, ()>,
 }
 
 impl NostrClient {
@@ -198,7 +199,26 @@ impl ClientHandler {
 
 				if let Ok(event) = handler_receive_lock.await.try_recv() {
 					println!("[CIVKITD] - PROCESSING: received an event from service manager");
-					client_event = Some(event);
+					// Handle server requests
+					if let ClientEvents::Server{ cmd } = event {
+						match cmd {
+							ServerCmd::GetClients { respond_to } => {
+								let all_clients = self.clients.values().cloned().collect::<Vec<NostrClient>>();
+								let _ = respond_to.send(all_clients);
+							},
+							ServerCmd::DisconnectClient { client_id } => {
+								let map_send_lock = self.map_send.lock();
+								if let Some(outgoing_send) = map_send_lock.await.get(&client_id) {
+									match outgoing_send.send(MAGIC_SERVER_PAYLOAD.clone().to_vec()) {
+										Ok(_) => {},
+										Err(_) => { println!("[CIVKITD] - NOSTR: Error inter thread sending disconnect"); }
+									}
+								}
+							},
+						}
+					} else {
+						client_event = Some(event)
+					}	
 				}
 			}
 
@@ -215,18 +235,6 @@ impl ClientHandler {
 							match outgoing_send.send(serialized_message.into_bytes()) {
 								Ok(_) => {},
 								Err(_) => { println!("[CIVKITD] - NOSTR: Error inter thread sending note"); }
-							}
-						},
-						ClientEvents::Server { ref cmd } => {
-							match cmd {
-								ServerCmd::DisconnectClient { client_id } => {
-									if id == client_id {
-										match outgoing_send.send(MAGIC_SERVER_PAYLOAD.clone().to_vec()) {
-											Ok(_) => {},
-											Err(_) => { println!("[CIVKITD] - NOSTR: Error inter thread sending disconnect"); }
-										}
-									}
-								}
 							}
 						},
 						ClientEvents::RelayNotice { ref message } => {

--- a/src/events.rs
+++ b/src/events.rs
@@ -10,9 +10,13 @@
 //! Internal events used to exchange information between ServiceManager and
 //! ClientHandler.
 
+use crate::clienthandler::NostrClient;
+
 use nostr::{Event, SubscriptionId};
 
-#[derive(Clone, Debug)]
+use tokio::sync::oneshot;
+
+#[derive(Debug)]
 pub enum ClientEvents {
 	TextNote { event: Event },
 	Server { cmd: ServerCmd },
@@ -21,9 +25,10 @@ pub enum ClientEvents {
 	SubscribedEvent { client_id: u64, sub_id: SubscriptionId, event: Event },
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum ServerCmd {
 	DisconnectClient { client_id: u64 },
+	GetClients { respond_to: oneshot::Sender<Vec<NostrClient>> }
 }
 
 pub trait EventsProvider {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@ pub mod kindprocessor;
 pub mod nodesigner;
 pub mod oniongateway;
 pub mod peerhandler;
+pub mod clienthandler;

--- a/src/proto/boardctrl.proto
+++ b/src/proto/boardctrl.proto
@@ -43,8 +43,15 @@ message ReceivedNote {
 message ListClientRequest {
 }
 
+message Client {
+	string pubkey = 1;
+	uint64 client_id = 2;
+	string associated_socket = 3;
+	uint64 subscriptions = 4;
+}
+
 message ListClientReply {
-	uint64 clients = 1;
+	repeated Client clients = 1;
 }
 
 message ListSubscriptionRequest {

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,10 +10,9 @@
 /// Main server of the CivKit Node, orchestrate all the components.
 
 mod boardmanager;
-mod clienthandler;
 
 use crate::boardmanager::ServiceManager;
-use crate::clienthandler::ClientHandler;
+use civkit::clienthandler::ClientHandler;
 use civkit::anchormanager::AnchorManager;
 use civkit::credentialgateway::CredentialGateway;
 use civkit::kindprocessor::NoteProcessor;


### PR DESCRIPTION
This PR allows the user to list the nostr clients that are connected to a civikit-node using the `civkit-cli listclients` command.

### Overview

The list of connected clients is part of `ClientHandler`. Instead of making that a shared state and pass it to `ServiceManager`, I used another approach (actors) which [seems](https://ryhl.io/blog/actors-with-tokio/) to [be popular](https://eo-rs.dev/blog/the-actor-pattern-with-async-rust/) for this kind of flows; from what I understand, `ClientHandler` already matches the description of an actor:
> "**The basic idea behind an actor** is to spawn a self-contained task that performs some job independently of other parts of the program. Typically these actors communicate with the rest of the program through the use of message passing channels. [...] A common use-case of actors is to assign the actor exclusive ownership of some resource you want to share, and then let other tasks access this resource indirectly by talking to the actor. " ~ [Actors with Tokio](https://ryhl.io/blog/actors-with-tokio/)

 This approach involves utilizing a channel between the requester and the responder(actor) to send a message that includes a one-shot channel through which the actor responds. We already have a `ServiceManager`->`ClientHandler` channel that sends `ClientEvents`, so I added a `GetClients` message with which the `ServiceManager` requests the clients' information alongside the one-shot channel
through which the `ClientHandler` responds.

### Test the change

1. Start a `civkitd` instance alongside two instance of `civkit-sample`.
2. From one of the `civkit-sample` instances, `opensubscription` and `sendtextnote`.
3. Preview of  `./civkit-cli listclients` command:
  ```
 [CIVKIT-CLI] clients [
    Client {
        pubkey: "ae065e37d162f14cfecd367a8717deebb47996024a5c81a5332861d66924ab18",
        client_id: 1,
        associated_socket: "[::1]:56912",
        subscriptions: 1,
    },
    Client {
        pubkey: "",
        client_id: 2,
        associated_socket: "[::1]:56918",
        subscriptions: 0,
    },
]
  ```