### PR TITLE
Add `publishinvoice` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ prost = "0.11"
 nostr = { git = "https://github.com/civkit/nostr.git", branch = "civkit-branch" }
 url = "2.4.0"
 clap = { version = "4.3.8", features = ["derive"] }
+serde_json = { version = "1.0" }
 
 [build-dependencies]
 tonic-build = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,11 @@ futures-channel = "0.3.28"
 futures-util = "0.3.28"
 lightning = { git = "https://github.com/civkit/rust-lightning.git", branch = "civkit-branch" }
 lightning-net-tokio = { git = "https://github.com/civkit/rust-lightning.git", branch = "civkit-branch" }
+lightning-invoice = { git = "https://github.com/civkit/rust-lightning.git", branch = "civkit-branch" }
 tokio = { version = "1", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
 tokio-tungstenite = "0.19.0"
 bitcoin = "0.29.0"
+bitcoin_hashes = { version = "0.11", default-features = false }
 tonic = "0.9"
 prost = "0.11"
 nostr = { git = "https://github.com/civkit/nostr.git", branch = "civkit-branch" }

--- a/README.md
+++ b/README.md
@@ -106,6 +106,31 @@ Connecting to a BOLT8 peer on local.
 [CIVKITD] - NET: inbound noise connection !
 ```
 
+Publishing a trade order (BOLT11 version).
+
+```
+./civkitd
+
+./civkit-cli publishinvoice lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpu9qrsgquk0rl77nj30yxdy8j9vdx85fkpmdla2087ne0xh8nhedh8w27kyke0lp53ut353s06fv3qfegext0eh0ymjpf39tuven09sam30g4vgpfna3rh
+
+./civkit-sample
+
+/* On logs of civkitd */
+[CIVKITD] - INIT: CivKit node starting up...
+[CIVKITD] - INIT: noise port 9735 nostr port 50021 cli_port 50031
+[CIVKITD] - NET: ready to listen tcp connection for clients !
+[CIVKITD] - NET: receive a tcp connection !
+[CIVKITD] - NET: incoming tcp Connection from :[::1]:50911
+[CIVKITD] - NET: websocket established: [::1]:50911
+[CIVKITD] - PROCESSING: received an event from service manager
+[CIVKITD] - NOSTR: sending event for client 1
+
+/* On logs of civkit-sample */
+Civkit sample startup successful. Enter "help" to view available commands
+> 
+[EVENT] new trade offer:  lnbc1pj2aey9dpzfpjhyefqvys8gunpv3jjq6twwehkjcm9yypp5qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsp59g4z52329g4z52329g4z52329g4z52329g4z52329g4z52329g4q9qrsgqcqzysk7er2zn07fwp0drlja8lf9lrre28qutvkqg4mrt8aa3y7kr33qhyfp903uyhtzlngv7a0yyg7kmx9alvejzk970p7834djwzxz60eggqt6upps
+```
+
 Development Process
 -------------------
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -182,7 +182,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 				.unwrap();
 
 			let request = tonic::Request::new(SendInvoice {
-				invoice: invoice.to_string().as_bytes().to_vec()
+				invoice: invoice.to_string()
 			});
 
 			let response = client.publish_invoice(request).await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,14 +8,19 @@
 // licenses.
 
 use boardctrl::board_ctrl_client::BoardCtrlClient;
-use boardctrl::{PingRequest, PongRequest, ShutdownRequest, ShutdownReply, SendNote, ReceivedNote, ListClientRequest, ListSubscriptionRequest, PeerConnectionRequest, DisconnectClientRequest, SendNotice, SendOffer};
+use boardctrl::{PingRequest, PongRequest, ShutdownRequest, ShutdownReply, SendNote, ReceivedNote, ListClientRequest, ListSubscriptionRequest, PeerConnectionRequest, DisconnectClientRequest, SendNotice, SendOffer, SendInvoice};
 
 use std::env;
 use std::process;
 
+use bitcoin_hashes::Hash;
+use bitcoin_hashes::sha256;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use bitcoin::KeyPair;
 use lightning::offers::offer::{Offer, OfferBuilder, Quantity};
+
+use lightning::ln::PaymentSecret;
+use lightning_invoice::{Currency, InvoiceBuilder};
 
 use lightning::util::ser::Writeable;
 
@@ -65,6 +70,9 @@ enum Command {
 		/// The BOLT12 offer to be announced
 		offer: String,
 	},
+	Publishinvoice {
+		invoice: String,
+	}
 }
 
 #[tokio::main]
@@ -154,6 +162,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 			});
 
 			let response = client.publish_offer(request).await?;
+		}
+		Command::Publishinvoice { invoice } => {
+			//TODO: tale real invoice from input
+			let secret_key = SecretKey::from_slice(&[42;32]).unwrap();
+	
+			let payment_hash = sha256::Hash::from_slice(&[0; 32][..]).unwrap();
+			let payment_secret = PaymentSecret([42u8;32]);
+
+			let invoice = InvoiceBuilder::new(Currency::Bitcoin)
+				.description("Here a trade invoice!".into())
+				.payment_hash(payment_hash)
+				.payment_secret(payment_secret)
+				.current_timestamp()
+				.min_final_cltv_expiry_delta(144)
+				.build_signed(|payment_hash| {
+					Secp256k1::new().sign_ecdsa_recoverable(payment_hash, &secret_key)
+				})
+				.unwrap();
+
+			let request = tonic::Request::new(SendInvoice {
+				invoice: invoice.to_string().as_bytes().to_vec()
+			});
+
+			let response = client.publish_invoice(request).await?;
 		}
 	}
 	Ok(())

--- a/src/clienthandler.rs
+++ b/src/clienthandler.rs
@@ -13,6 +13,7 @@ use bitcoin::secp256k1;
 use bitcoin::secp256k1::SecretKey;
 use bitcoin::secp256k1::Secp256k1;
 
+
 use nostr::{RelayMessage, Event, ClientMessage, SubscriptionId, Filter};
 use nostr::key::XOnlyPublicKey;
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -20,6 +20,7 @@ use tokio::sync::oneshot;
 pub enum ClientEvents {
 	TextNote { event: Event },
 	Server { cmd: ServerCmd },
+	Invoice { },
 	EndOfStoredEvents { client_id: u64, sub_id: SubscriptionId },
 	RelayNotice { message: String },
 	OrderNote { order: Event },

--- a/src/events.rs
+++ b/src/events.rs
@@ -20,10 +20,9 @@ use tokio::sync::oneshot;
 pub enum ClientEvents {
 	TextNote { event: Event },
 	Server { cmd: ServerCmd },
-	Invoice { },
+	OrderNote { order: Event },
 	EndOfStoredEvents { client_id: u64, sub_id: SubscriptionId },
 	RelayNotice { message: String },
-	OrderNote { order: Event },
 	SubscribedEvent { client_id: u64, sub_id: SubscriptionId, event: Event },
 }
 

--- a/src/oniongateway.rs
+++ b/src/oniongateway.rs
@@ -45,6 +45,7 @@ impl OnionBox {
 		let logger = Arc::new(FakeLogger {});
 		let ignoring_message_handler = IgnoringMessageHandler {};
 
+		//TODO: harmonize code between rust lightning crates about OnionMessenger
 		//let onion_messenger = OnionMessenger::new(&keys_manager, &keys_manager_2, logger, &ignoring_message_handler);
 
 		OnionBox {

--- a/src/proto/boardctrl.proto
+++ b/src/proto/boardctrl.proto
@@ -17,6 +17,7 @@ service BoardCtrl {
 	/* NIP 01 - from relay to client: NOTICE */
 	rpc PublishNotice (SendNotice) returns (ReceivedNotice);
 	rpc PublishOffer (SendOffer) returns (ReceivedOffer);
+	rpc PublishInvoice (SendInvoice) returns (ReceivedInvoice);
 }
 
 message PingRequest {
@@ -104,4 +105,11 @@ message SendOffer {
 }
 
 message ReceivedOffer {
+}
+
+message SendInvoice {
+	bytes invoice = 1;
+}
+
+message ReceivedInvoice {
 }

--- a/src/proto/boardctrl.proto
+++ b/src/proto/boardctrl.proto
@@ -108,7 +108,7 @@ message ReceivedOffer {
 }
 
 message SendInvoice {
-	bytes invoice = 1;
+	string invoice = 1;
 }
 
 message ReceivedInvoice {

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,6 +25,8 @@ use civkit::events::{ClientEvents, EventsProvider, ServerCmd};
 
 use lightning::offers::offer::Offer;
 
+use lightning_invoice::Invoice;
+
 use boardctrl::board_ctrl_server::{BoardCtrl, BoardCtrlServer};
 
 use clap::Parser;
@@ -203,9 +205,12 @@ impl BoardCtrl for ServiceManager {
 		let invoice_message = request.into_inner().invoice;
 
 		let service_keys = Keys::generate();
+		//let invoice: Invoice = serde_json::from_str(&invoice_message).unwrap();
+		//let encoded_invoice = invoice.to_string();
+		if let Ok(kind32500_event) = EventBuilder::new_order_note(invoice_message, &[]).to_event(&service_keys)
 		{
-			let mut board_send_lock = self.service_events_send.lock().unwrap();
-			board_send_lock.send(ClientEvents::Invoice { });
+				let mut board_send_lock = self.service_events_send.lock().unwrap();
+				board_send_lock.send(ClientEvents::OrderNote { order: kind32500_event });
 		}
 
 		Ok(Response::new(boardctrl::ReceivedInvoice {}))

--- a/src/server.rs
+++ b/src/server.rs
@@ -198,6 +198,18 @@ impl BoardCtrl for ServiceManager {
 
 		Ok(Response::new(boardctrl::ReceivedOffer {}))
 	}
+
+	async fn publish_invoice(&self, request: Request<boardctrl::SendInvoice>) -> Result<Response<boardctrl::ReceivedInvoice>, Status> {
+		let invoice_message = request.into_inner().invoice;
+
+		let service_keys = Keys::generate();
+		{
+			let mut board_send_lock = self.service_events_send.lock().unwrap();
+			board_send_lock.send(ClientEvents::Invoice { });
+		}
+
+		Ok(Response::new(boardctrl::ReceivedInvoice {}))
+	}
 }
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
It will take few years for the offers format to become standard across the Lightning wallet payment ecosystem. A payment protocol is a fundamental part of the civkit’s trading protocol as described in the paper, so if we wanna to have the board functional during the coming month(s) with some Lightning wallets, we’ll be better off to have support for both bolt11 and bolt12 formats.

This PR introduces a `publishinvoice` command which accept directly a BOLT11 string. Still have to hack the support on the client-side to publish as an event, and see how to integrate with nostr.