### PR TITLE
Move`NoteProcessor` in its own thread

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,7 @@
 // licenses.
 
 use boardctrl::board_ctrl_client::BoardCtrlClient;
-use boardctrl::{PingRequest, PongRequest, ShutdownRequest, ShutdownReply, SendNote, ReceivedNote, ListClientRequest, ListSubscriptionRequest, PeerConnectionRequest, DisconnectClientRequest, SendNotice, SendOffer, SendInvoice, ListDbEntriesRequest};
+use boardctrl::{PingRequest, PongRequest, ShutdownRequest, ShutdownReply, SendNote, ReceivedNote, ListClientRequest, ListSubscriptionRequest, PeerConnectionRequest, DisconnectClientRequest, SendNotice, SendOffer, SendInvoice, ListDbEventsRequest};
 
 use std::env;
 use std::process;
@@ -74,7 +74,7 @@ enum Command {
 		invoice: String,
 	},
 	/// List DB entries
-	ListDbEntries
+	ListDbEvents
 }
 
 #[tokio::main]
@@ -189,10 +189,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 			let response = client.publish_invoice(request).await?;
 		}
-		Command::ListDbEntries => {
-			let request = tonic::Request::new(ListDbEntriesRequest {});
+		Command::ListDbEvents => {
+			let request = tonic::Request::new(ListDbEventsRequest {});
 
-			let _response = client.list_db_entries(request).await?;
+			let _response = client.list_db_events(request).await?;
 		}
 	}
 	Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use bitcoin::secp256k1::PublicKey;
 
 use nostr::{SubscriptionId, Filter};
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct NostrSub {
 	our_side_id: u64,
 	id: SubscriptionId,
@@ -36,7 +36,7 @@ impl NostrSub {
 	}
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct NostrPeer {
 	peer_pubkey: PublicKey,
 }

--- a/src/nostr_db.rs
+++ b/src/nostr_db.rs
@@ -11,28 +11,48 @@ use nostr::Event;
 
 use crate::{NostrSub, NostrPeer};
 
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OpenFlags, params};
+
+use std::path::Path;
 
 const CIVKITD_DB_FILE: &str = "civkitd.db";
 
+#[derive(Debug)]
+pub enum DbRequest {
+	WriteEvent(Event),
+	WriteSub(NostrSub),
+	DumpEvents,
+}
+
+#[derive(Debug)]
 struct DbEvent {
 	id: i32,
 	data: Option<Vec<u8>>,
 }
 
+#[derive(Debug)]
 struct DbSub {
 	sub_id: i32,
 	data: Option<Vec<u8>>,
 }
 
-pub async fn log_new_event_db(event: Event) {
+pub async fn write_new_event_db(event: Event) {
 
-	if let Ok(conn) = Connection::open_in_memory() {
-		conn.execute("CREATE TABLE event (
+	//TODO: spawn new thread
+	if let Ok(mut conn) = Connection::open_with_flags(
+		Path::new(CIVKITD_DB_FILE),
+		OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE
+	) {
+		println!("[CIVKITD] - NOTE PROCESSING: Opening database for read / write new event");
+
+		match conn.execute("CREATE TABLE event (
 			event_id	INTEGER PRIMARY KEY,
 			data		BLOB
 		)",
-		());
+		()) {
+			Ok(create) => println!("[CIVKITD] - NOTE PROCESSING: {} rows were updated", create),
+			Err(err) => println!("[CIVKITD] - NOTE PROCESSING: table creation failed: {}", err),
+		}
 
 		//TODO: add complete event
 		let event = DbEvent {
@@ -40,14 +60,44 @@ pub async fn log_new_event_db(event: Event) {
 			data: None,
 		};
 
-		conn.execute(
-			"INSERT INTO event (data) VALUES (:data)",
+		match conn.execute("INSERT INTO event (data) VALUES (:data)",
 			&[(&event.data)],
-		);
-	}
+		) {
+			Ok(update) => println!("[CIVKITD] - NOTE PROCESSING: {} rows were updated", update),
+			Err(err) => println!("[CIVKITD] - NOTE PROCESSING: update insert failed: {}", err),
+		}
+
+		conn.close().ok();
+	} else { println!("Failure to open database"); }
 }
 
-pub async fn log_new_subscription_db(subscription: NostrSub) {
+pub async fn print_events_db() {
+
+	if let Ok(mut conn) = Connection::open_with_flags(
+		Path::new(CIVKITD_DB_FILE),
+		OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_CREATE
+	) {
+		println!("[CIVKITD] - NOTE PROCESSING: Opening database for read events");
+
+		{
+			let mut stmt = conn.prepare("SELECT event_id, data FROM event").unwrap();
+			let event_iter = stmt.query_map([], |row| {
+				Ok(DbEvent {
+					id: row.get(0)?,
+					data: row.get(1)?,
+				})
+			}).unwrap();
+
+			for event in event_iter {
+				println!("[CIVKITD] - NOTE PROCESSING: Found event {:?}", event.unwrap());
+			}
+		}
+
+		conn.close().ok();
+	} else { println!("Failure to open database"); }
+}
+
+pub async fn write_new_subscription_db(subscription: NostrSub) {
 
 	if let Ok(conn) = Connection::open_in_memory() {
 		conn.execute("CREATE TABLE event (
@@ -89,8 +139,4 @@ pub async fn log_new_peer_db(peer: NostrPeer) {
 	}
 }
 
-//pub async fn log_new_nostr_client(nostr_client: NostrClient) {
-//
-//}
-
-//TODO log clients and peers
+//TODO: log function for client

--- a/src/proto/boardctrl.proto
+++ b/src/proto/boardctrl.proto
@@ -18,7 +18,7 @@ service BoardCtrl {
 	rpc PublishNotice (SendNotice) returns (ReceivedNotice);
 	rpc PublishOffer (SendOffer) returns (ReceivedOffer);
 	rpc PublishInvoice (SendInvoice) returns (ReceivedInvoice);
-	rpc ListDbEntries (ListDbEntriesRequest) returns (ListDbEntriesReply);
+	rpc ListDbEvents (ListDbEventsRequest) returns (ListDbEventsReply);
 }
 
 message PingRequest {
@@ -115,8 +115,8 @@ message SendInvoice {
 message ReceivedInvoice {
 }
 
-message ListDbEntriesRequest {
+message ListDbEventsRequest {
 }
 
-message ListDbEntriesReply {
+message ListDbEventsReply {
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,6 +15,7 @@ mod config;
 use std::fs;
 use crate::config::Config;
 use crate::boardmanager::ServiceManager;
+use civkit::nostr_db::DbRequest;
 use civkit::clienthandler::{NostrClient, ClientHandler};
 use civkit::anchormanager::AnchorManager;
 use civkit::credentialgateway::CredentialGateway;
@@ -161,7 +162,9 @@ impl BoardCtrl for ServiceManager {
 
 	async fn status_handle(&self, request: Request<boardctrl::BoardStatusRequest>) -> Result<Response<boardctrl::BoardStatusReply>, Status> {
 
-		let notes = self.note_stats();
+		//TODO give a mspc communication channel between ServiceManager and NoteProcessor
+		let notes = 0;
+		//let notes = self.note_stats();
 
 		let board_status = boardctrl::BoardStatusReply {
 			offers: notes,
@@ -219,11 +222,16 @@ impl BoardCtrl for ServiceManager {
 		Ok(Response::new(boardctrl::ReceivedInvoice {}))
 	}
 
-	async fn list_db_entries(&self, request: Request<boardctrl::ListDbEntriesRequest>) -> Result<Response<boardctrl::ListDbEntriesReply>, Status> {
+	async fn list_db_events(&self, request: Request<boardctrl::ListDbEventsRequest>) -> Result<Response<boardctrl::ListDbEventsReply>, Status> {
 
-		println!("[CIVKITD] - CONTROL: listing DB entries !");
+		println!("[CIVKITD] - CONTROL: listing DB event !");
 
-		Ok(Response::new(boardctrl::ListDbEntriesReply {}))
+		{
+			let mut send_db_request_lock = self.send_db_request.lock().unwrap();
+			send_db_request_lock.send(DbRequest::DumpEvents);
+		}
+
+		Ok(Response::new(boardctrl::ListDbEventsReply {}))
 	}
 }
 
@@ -266,6 +274,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	// We initialize the communication channels between the nostr tcp listener and ClientHandler.
 	let (socket_connector, request_receive) = mpsc::unbounded_channel::<(TcpStream, SocketAddr)>();
 
+	// We initialize the communication channels between the NoteProcessor and ClientHandler.
+	let (handler_send_dbrequests, processor_receive_dbrequests) = mpsc::unbounded_channel::<(DbRequest)>();
+
+	// We initialize the communication channels between the NoteProcessor and ServiceManager.
+	let (manager_send_dbrequests, receive_dbrequests_manager) = mpsc::unbounded_channel::<(DbRequest)>();
+
 	// The onion message handler...quite empty for now.
 	let onion_box = OnionBox::new();
 
@@ -276,7 +290,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let credential_gateway = Arc::new(CredentialGateway::new());
 
 	// The note or service provider...quite empty for now.
-	let note_processor = Arc::new(NoteProcessor::new());
+	let mut note_processor = NoteProcessor::new(processor_receive_dbrequests, receive_dbrequests_manager);
 
 	// The service provider signer...quite empty for now.
 	let node_signer = Arc::new(NodeSigner::new());
@@ -285,10 +299,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let anchor_manager = Arc::new(AnchorManager::new());
 
 	// Main handler of Nostr connections.
-	let mut client_handler = ClientHandler::new(handler_receive, request_receive);
+	let mut client_handler = ClientHandler::new(handler_receive, request_receive, handler_send_dbrequests);
 
 	// Main handler of services provision.
-	let board_manager = ServiceManager::new(credential_gateway, node_signer, anchor_manager, note_processor, board_events_send, board_peer_send);
+	let board_manager = ServiceManager::new(credential_gateway, node_signer, anchor_manager, board_events_send, board_peer_send, manager_send_dbrequests);
 
 	let addr = format!("[::1]:{}", cli.cli_port).parse()?;
 
@@ -317,6 +331,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	// We start the onion box for received onions.
 	tokio::spawn(async move {
 		onion_box.run().await;
+	});
+
+	// We start the note processor for messages.
+	tokio::spawn(async move {
+		note_processor.run().await;
 	});
 
 	// We start the noise gateway for BOLT8 peers.


### PR DESCRIPTION
Building on top of the SQLite support #24, this PR moves `NoteProcessor` out of `ServiceManager` and aims to be the module receiving the DB write/read request from the other components (client handler, gateway, RPC client).

`NoteProcessor` is a good module candidate to support NIP33 queries (see #22) as event will have to be pruned out of the database, if they’re replaced.