### PR TITLE
Fix CI builds by installing libsqlite3-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Install dependencies
       run: |
           apt-get update
-          apt-get install -y curl gcc protobuf-compiler
+          apt-get install -y curl gcc protobuf-compiler libsqlite3-dev
 
     - name: Install Rust Toolchain (stable)
       shell: bash


### PR DESCRIPTION
Credits to dapsavoie (@dapsavoie) for the CI fix. Picked it up from #33 to fix CI quickly and keep moving forward while #33 is landing, thanks for it.