### PR TITLE
added loggin severity levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 # will have compiled files and executables
 /target/
 Cargo.lock
+debug.log

--- a/check_config.sh
+++ b/check_config.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Define the path to the config file
+CONFIG_FILE="./example-config.toml"
+
+# Check if the file exists
+if [[ ! -f $CONFIG_FILE ]]; then
+    echo "example-config.toml not found. Creating a default one..."
+
+    # Define the default content for the config file
+    config_content='[performance]
+max_db_size = 10000
+max_event_age = 3600
+
+[spam_protection]
+requestcredentials = true
+
+[connections]
+maxclientconnections = 100
+
+[civkitd]
+network = "testnet"
+noise_port = 9735
+nostr_port = 50021
+cli_port = 50031
+
+[logging]
+level = "info"'
+
+    # Write the default content to the config file
+    echo "$config_content" > $CONFIG_FILE
+else
+    echo "example-config.toml already exists."
+fi

--- a/debug.log
+++ b/debug.log
@@ -1,1 +1,4 @@
-18:58:02 [ INFO] Logging initialized. Log file located at: "/home/daven/./civkit-node/debug.log"
+10:25:07 [ INFO] Logging initialized. Log file located at: "/home/daven/./civkit-node/debug.log"
+10:25:07 [ERROR] This is a test error message
+10:25:07 [ WARN] This is a test warning message
+10:25:07 [ INFO] This is a test info message

--- a/example-config.toml
+++ b/example-config.toml
@@ -13,3 +13,6 @@ network = "testnet"
 noise_port = 9735
 nostr_port = 50021
 cli_port = 50031
+
+[logging]
+level = "info"

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ pub struct Config {
     pub spam_protection: SpamProtection,
     pub connections: Connections,
     pub civkitd: Civkitd,
+    pub logging: Logging,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
@@ -32,4 +33,36 @@ pub struct Civkitd {
     pub noise_port: i32,
     pub nostr_port: i32,
     pub cli_port: i32,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
+pub struct Logging {
+    pub level: String,
+}
+
+// default config to fallback
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            performance: Performance {
+                max_db_size: 10000,
+                max_event_age: 3600,
+            },
+            spam_protection: SpamProtection {
+                requestcredentials: true,
+            },
+            connections: Connections {
+                maxclientconnections: 100,
+            },
+            civkitd: Civkitd {
+                network: "testnet".to_string(),
+                noise_port: 9735,
+                nostr_port: 50021,
+                cli_port: 50031,
+            },
+            logging: Logging {
+                level: "info".to_string(),
+            },
+        }
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -267,18 +267,30 @@ struct Cli {
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let data_dir = util::get_default_data_dir();
 
-    // Initialize the logger
-    //let log_writer = util::init_logger(&data_dir)?;
+	let config_path = data_dir.join("example-config.toml");
 
-    // Initialize the logger and log the log file path
+    // Read the configuration file
+    let contents = fs::read_to_string(&config_path);
+    let config = match contents {
+        Ok(data) => {
+            toml::from_str(&data).expect("Could not deserialize the config file content")
+        },
+        Err(_) => {
+            // If there's an error reading the file, use the default configuration
+            Config::default()
+        }
+    };
+    // Initialize the logger with the level from the config
+    util::init_logger(&data_dir, &config.logging.level)?;
+
     log::info!("Logging initialized. Log file located at: {:?}", data_dir.join("debug.log"));
 
-    let contents = fs::read_to_string("./example-config.toml")
-        .expect("Something went wrong reading the file");
-
-    let config: Config = toml::from_str(&contents)
-        .expect("Could not deserialize the config file content");
-
+    // Test logging at different levels
+    log::error!("This is a test error message");
+    log::warn!("This is a test warning message");
+    log::info!("This is a test info message");
+    log::debug!("This is a test debug message");
+    log::trace!("This is a test trace message");
     // Log the parsed configuration data
     //log::info!("Parsed configuration: {:?}", config);	
 	let cli = Cli::parse();

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 use std::convert::Infallible;
 use tokio::sync::mpsc;
 use std::io::Write; 
+use std::fs;
+
 
 pub fn get_default_data_dir() -> PathBuf {
     let home_dir = dirs::home_dir().expect("Home directory not found");
@@ -29,16 +31,27 @@ pub fn get_default_data_dir() -> PathBuf {
 }
 
 // Function to initialize the logger with the given data directory
-pub fn init_logger(data_dir: &PathBuf) -> Result<(), Box<dyn Error + Send + Sync>> {
+pub fn init_logger(data_dir: &PathBuf, log_level: &str ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    
+    if !data_dir.exists() {
+        fs::create_dir_all(data_dir)?;
+    }
+    
     let log_file = data_dir.join("debug.log");
-
     let config = ConfigBuilder::new().build();
-    let log_writer = File::create(&log_file)?;
-    let log_writer = WriteLogger::new(LevelFilter::Trace, config.clone(), log_writer);
+    let level_filter = match log_level {
+        "error" => LevelFilter::Error,
+        "warn" => LevelFilter::Warn,
+        "info" => LevelFilter::Info,
+        "debug" => LevelFilter::Debug,
+        "trace" => LevelFilter::Trace,
+        _ => panic!("Invalid log level in config"),
+    };
 
-    CombinedLogger::init(vec![
-        TermLogger::new(LevelFilter::Info, config.clone(), TerminalMode::Mixed).unwrap(),
-        log_writer,
-    ])
-    .map_err(|err| Box::new(err) as Box<dyn Error + Send + Sync>)
+    let log_writer = File::create(&log_file)?;
+    let file_logger = WriteLogger::new(level_filter, config.clone(), log_writer);
+    let term_logger = TermLogger::new(level_filter, config, TerminalMode::Mixed).unwrap();
+
+    CombinedLogger::init(vec![file_logger, term_logger])
+        .map_err(|err| Box::new(err) as Box<dyn Error + Send + Sync>)
 }


### PR DESCRIPTION
Pr changes are as follows: 

- Updated `util.rs` , specifically `init_logger` with multiple level filters (error, warn, info, debug, trace). 

- Updated `config.toml` with `[logging]` and `level `where this value can be set by user.

- Updated` config.rs` with new struct to handle logging from `config.toml`.

These 3 updates make it possible to configure` level `from `config.toml` as per the user requirements. 

For testing error messages, I modified the nip-01 listener to exit gracefully if the port binding fails and log the message as an 'error' in logs. If you forgot to kill your previous civkit instance, it will let you know with an error log now. I can modify this if it impacts the function behavior in anyway but wanted to give an example of an error outside of toml parsing.

For testing info level, I modified the toml parser to log at an info level which was working on my end. 

Please review this PR and let me know any updates.

