### PR TITLE
Introduce market board daemon `civkit-marketd`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/client.rs"
 name = "civkit-sample"
 path = "src/sample.rs"
 
+[[bin]]
+name = "civkit-marketd"
+path = "src/services/marketd.rs"
+
 [dependencies]
 futures-channel = "0.3.28"
 futures-util = "0.3.28"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 	tonic_build::compile_protos("src/proto/adminctrl.proto")?;
+	tonic_build::compile_protos("src/proto/civkitservice.proto")?;
 	Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-	tonic_build::compile_protos("src/proto/boardctrl.proto")?;
+	tonic_build::compile_protos("src/proto/adminctrl.proto")?;
 	Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,9 +7,9 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-use boardctrl::board_ctrl_client::BoardCtrlClient;
+use adminctrl::admin_ctrl_client::AdminCtrlClient;
 //TODO: simplify by using prefix
-use boardctrl::{PingRequest, PongRequest, ShutdownRequest, ShutdownReply, SendNote, ReceivedNote, ListClientRequest, ListSubscriptionRequest, PeerConnectionRequest, DisconnectClientRequest, SendNotice, SendOffer, SendInvoice, ListDbEventsRequest, ListDbClientsRequest, ListDbClientsReply};
+use adminctrl::{PingRequest, PongRequest, ShutdownRequest, ShutdownReply, SendNote, ReceivedNote, ListClientRequest, ListSubscriptionRequest, PeerConnectionRequest, DisconnectClientRequest, SendNotice, SendOffer, SendInvoice, ListDbEventsRequest, ListDbClientsRequest, ListDbClientsReply};
 
 use std::env;
 use std::process;
@@ -31,8 +31,8 @@ use tokio::time::Duration;
 
 use clap::{Parser, Subcommand};
 
-pub mod boardctrl {
-	tonic::include_proto!("boardctrl");
+pub mod adminctrl {
+	tonic::include_proto!("adminctrl");
 }
 
 #[derive(Parser, Debug)]
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	let cli = Cli::parse();
 
-	let mut client = BoardCtrlClient::connect(format!("http://[::1]:{}", cli.port)).await?;
+	let mut client = AdminCtrlClient::connect(format!("http://[::1]:{}", cli.port)).await?;
 
 	match cli.command {
 		Command::Ping => {

--- a/src/proto/adminctrl.proto
+++ b/src/proto/adminctrl.proto
@@ -1,9 +1,9 @@
 
 syntax = "proto3";
 
-package boardctrl;
+package adminctrl;
 
-service BoardCtrl {
+service AdminCtrl {
 	rpc PingHandle (PingRequest) returns (PongRequest);
 	rpc ShutdownHandle (ShutdownRequest) returns (ShutdownReply);
 	/* NIP 01 from client to relay - EVENT: Kind 1 `text_note` */
@@ -12,7 +12,7 @@ service BoardCtrl {
 	rpc ListSubscriptions (ListSubscriptionRequest) returns (ListSubscriptionReply);
 	rpc ConnectPeer (PeerConnectionRequest) returns (PeerConnectionReply);
 	rpc ListPeers (ListPeersRequest) returns (ListPeersReply);
-	rpc StatusHandle (BoardStatusRequest) returns (BoardStatusReply);
+	rpc RelayStatusHandle (ServiceMngrStatusRequest) returns (ServiceMngrStatusReply);
 	rpc DisconnectClient (DisconnectClientRequest) returns (DisconnectClientReply);
 	/* NIP 01 - from relay to client: NOTICE */
 	rpc PublishNotice (SendNotice) returns (ReceivedNotice);
@@ -81,10 +81,10 @@ message ListPeersReply {
 	uint64 peers = 1;
 }
 
-message BoardStatusRequest {
+message ServiceMngrStatusRequest {
 }
 
-message BoardStatusReply {
+message ServiceMngrStatusReply {
 	uint64 offers = 1;
 }
 

--- a/src/proto/civkitservice.proto
+++ b/src/proto/civkitservice.proto
@@ -1,0 +1,16 @@
+
+syntax = "proto3";
+
+package civkitservice;
+
+service CivkitService {
+	rpc RegisterService(RegisterRequest) returns (RegisterReply);
+}
+
+message RegisterRequest {
+	bytes service_pubkey = 1;
+}
+
+message RegisterReply {
+	uint64 registration_result = 1;
+}

--- a/src/servicemanager.rs
+++ b/src/servicemanager.rs
@@ -1,0 +1,71 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! The ServiceManager responsible to sanitze service kinds note, counter-sign
+//! and chain notarize them and dispatch them to peers or clients accordingly.
+
+use bitcoin::BlockHash;
+use bitcoin::blockdata::constants::genesis_block;
+use bitcoin::network::constants::Network;
+
+use bitcoin::secp256k1::{SecretKey, PublicKey};
+use bitcoin::secp256k1::Secp256k1;
+use bitcoin::secp256k1;
+
+use civkit::nostr_db::DbRequest;
+use civkit::anchormanager::AnchorManager;
+use civkit::credentialgateway::CredentialGateway;
+use civkit::events::ClientEvents;
+use civkit::nodesigner::NodeSigner;
+use civkit::peerhandler::PeerInfo;
+use civkit::config::Config;
+
+// use lock from futures::lock
+use std::sync::Mutex;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+pub struct ServiceManager
+{
+	//default_configuration: 
+	genesis_hash: BlockHash,
+
+	//TODO: abstract ServiceProcessor, ServiceSigner and AnchorManager in its own Service component ?
+	node_signer: Arc<NodeSigner>,
+	anchor_manager: Arc<AnchorManager>,
+
+	pub service_events_send: Mutex<mpsc::UnboundedSender<ClientEvents>>,
+	pub service_peers_send: Mutex<mpsc::UnboundedSender<PeerInfo>>,
+
+	pub send_db_request: Mutex<mpsc::UnboundedSender<DbRequest>>,
+
+	our_service_pubkey: PublicKey,
+	config: Config,
+	secp_ctx: Secp256k1<secp256k1::All>,
+}
+
+impl ServiceManager
+{
+	pub fn new(node_signer: Arc<NodeSigner>, anchor_manager: Arc<AnchorManager>, board_events_send: mpsc::UnboundedSender<ClientEvents>, board_peers_send: mpsc::UnboundedSender<PeerInfo>, send_db_request: mpsc::UnboundedSender<DbRequest>, our_config: Config) -> Self {
+		let secp_ctx = Secp256k1::new();
+		let pubkey = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42;32]).unwrap());
+		ServiceManager {
+			genesis_hash: genesis_block(Network::Testnet).header.block_hash(),
+			anchor_manager,
+			node_signer,
+			service_events_send: Mutex::new(board_events_send),
+			service_peers_send: Mutex::new(board_peers_send),
+			send_db_request: Mutex::new(send_db_request),
+			our_service_pubkey: pubkey,
+			config: our_config,
+			secp_ctx,
+		}
+	}
+}

--- a/src/services/marketd.rs
+++ b/src/services/marketd.rs
@@ -1,0 +1,36 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+use civkitservice::civkit_service_client::CivkitServiceClient;
+
+use civkitservice::{RegisterRequest, RegisterReply};
+
+use bitcoin::secp256k1::{SecretKey, PublicKey, Secp256k1};
+use bitcoin::secp256k1;
+
+pub mod civkitservice {
+	tonic::include_proto!("civkitservice");
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+
+	let mut civkitd_client = CivkitServiceClient::connect(format!("http://[::1]:{}", 50031)).await?;
+
+	let secp_ctx = Secp256k1::new();
+	let pubkey = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[42;32]).unwrap());
+
+	let request = tonic::Request::new(RegisterRequest {
+		service_pubkey: pubkey.serialize().to_vec()
+	});
+
+	let response = civkitd_client.register_service(request).await?;
+
+	Ok(())
+}


### PR DESCRIPTION
This PR renames the former `boardctrl` gRPC API to `adminctrl` API, as its purpose is just to provide a simple endpoint for administration and resource management of `civkit-node` as a Nostr relay and LN peer.

Beyond, this PR introduces a new gRPC API `civkitservice.proto` and a new daemon `civkit-marketd` aiming to support the exchange-like market board functionalities. This new API can be used to build and register other services like notary servers.

TODO: replace the `DummyStruct` by a real component.