### PR TITLE
Begin NIP-16-support

### DIFF
--- a/src/clienthandler.rs
+++ b/src/clienthandler.rs
@@ -21,6 +21,7 @@ use crate::config::Config;
 use crate::{events, NostrSub, NostrClient};
 use crate::events::{ClientEvents, EventsProvider, ServerCmd};
 use crate::nostr_db::DbRequest;
+use crate::util::is_ephemeral;
 
 use futures_util::{future, pin_mut, TryStreamExt, StreamExt, SinkExt};
 
@@ -348,8 +349,10 @@ impl ClientHandler {
 								self.filter_events(*msg).await;
 								//TODO: we should link our filtering policy to our db storing,
 								//otherwise this is a severe DoS vector
-								let db_request = DbRequest::WriteEvent(*msg_2);
-								write_db.push(db_request);
+								if !is_ephemeral(&msg_2) {
+									let db_request = DbRequest::WriteEvent(*msg_2);
+									write_db.push(db_request);
+								}
 							},
 							ClientMessage::Req { subscription_id, filters } => {
 								self.subscriptions_counter += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,3 +105,4 @@ pub mod oniongateway;
 pub mod peerhandler;
 pub mod clienthandler;
 pub mod config;
+pub mod util;

--- a/src/nostr_db.rs
+++ b/src/nostr_db.rs
@@ -49,7 +49,7 @@ struct DbClient {
 	data: Option<Vec<u8>>,
 }
 
-pub async fn write_new_event_db(event: Event) {
+pub async fn write_new_event_db(event: Event, old_event: Option<Vec<Event>>) {
 
 	//TODO: spawn new thread
 	if let Ok(mut conn) = Connection::open_with_flags(

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+use nostr::Event;
+
 use log::LevelFilter;
 use simplelog::{CombinedLogger, ConfigBuilder, TermLogger, WriteLogger, TerminalMode};
 use std::error::Error;
@@ -54,4 +56,20 @@ pub fn init_logger(data_dir: &PathBuf, log_level: &str ) -> Result<(), Box<dyn E
 
     CombinedLogger::init(vec![file_logger, term_logger])
         .map_err(|err| Box::new(err) as Box<dyn Error + Send + Sync>)
+}
+
+// Function to assert if an event is a NIP-16 ephemeral event
+pub fn is_ephemeral(ev: &Event) -> bool {
+	if 20000 <= ev.kind.as_u32() && ev.kind.as_u32() < 30000 {
+		return false;
+	}
+	return true;
+}
+
+// Function to assert if an event is a NIP-16 repleceable event
+pub fn is_replaceable(ev: &Event) -> bool {
+	if 10000 <= ev.kind.as_u32() && ev.kind.as_u32() < 20000 {
+		return false;
+	}
+	return true;
 }


### PR DESCRIPTION
Address #47

NIP-16 introduces two event processing policy rules for relay:
- regular events (`is_ephemeral()` in our codebase)
- replaceable events (`is_replaceable()` in our codebase)

We check for ephemeral in `ClientHandler` before any inter-thread message passing, and avoid locks. For `is_replaceable` processing responsibility is thrown on the `NoteProcessor`.

Few TODOs to get done, notably having authors filtering working.