### PR TITLE
Add CredentialPolicy and push NIP Notice to new client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ rusqlite = "0.29.0"
 simplelog = "0.7.1"
 dirs = "3.0.1"
 log = "0.4.14"
+staking_credentials = { git = "https://github.com/civkit/staking-credentials.git", branch = "main" }
 
 
 [build-dependencies]

--- a/src/events.rs
+++ b/src/events.rs
@@ -23,7 +23,7 @@ pub enum ClientEvents {
 	OrderNote { order: Event },
 	StoredEvent { client_id: u64, events: Vec<Event> },
 	EndOfStoredEvents { client_id: u64, sub_id: SubscriptionId },
-	RelayNotice { message: String },
+	RelayNotice { client_id: u64, message: String },
 	SubscribedEvent { client_id: u64, sub_id: SubscriptionId, event: Event },
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -191,7 +191,7 @@ impl AdminCtrl for ServiceManager {
 
 		{
 			let mut service_mngr_send_lock = self.service_events_send.lock().unwrap();
-			service_mngr_send_lock.send(ClientEvents::RelayNotice { message: notice_message });
+			service_mngr_send_lock.send(ClientEvents::RelayNotice { client_id: 0, message: notice_message });
 		}
 
 		let received_note = adminctrl::ReceivedNote {


### PR DESCRIPTION
This PR starts the integration of the Staking Credentials framework (https://github.com/civkit/staking-credentials) into `civkitd`.

ClientHandler will push a new NIP Notice to client at starting containing the credentials policy to publish on the server.