### PR TITLE
Add BitcoindClient to access bitcoind

### DIFF
--- a/src/bitcoind_client.rs
+++ b/src/bitcoind_client.rs
@@ -1,0 +1,34 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+pub struct BitcoindClient {
+	host: String,
+	port: u16,
+	rpc_user: String,
+	rpc_password: String,
+}
+
+impl BitcoindClient {
+	pub fn new(host: String, port: u16, rpc_user: String, rpc_password: String) -> Self {
+		BitcoindClient {
+			host: host,
+			port: port,
+			rpc_user: rpc_user,
+			rpc_password: rpc_password,
+		}
+	}
+
+	pub async fn gettxoutproof() {
+
+	}
+
+	pub async fn verifytxoutproof() {
+
+	}
+}

--- a/src/credentialgateway.rs
+++ b/src/credentialgateway.rs
@@ -19,6 +19,8 @@ use bitcoin::secp256k1;
 
 use staking_credentials::issuance::issuerstate::IssuerState;
 
+use crate::bitcoind_client::BitcoindClient;
+
 use tokio::time::{sleep, Duration};
 
 #[derive(Copy, Clone, Debug)]
@@ -43,6 +45,8 @@ struct IssuanceManager {
 }
 
 pub struct CredentialGateway {
+	bitcoind_client: BitcoindClient,
+
 	genesis_hash: BlockHash,
 
 	default_config: GatewayConfig,
@@ -54,10 +58,12 @@ pub struct CredentialGateway {
 
 impl CredentialGateway {
 	pub fn new() -> Self {
+		let bitcoind_client = BitcoindClient::new(String::new(), 0, String::new(), String::new());
 		let secp_ctx = Secp256k1::new();
 		//TODO: should be given a path to bitcoind to use the wallet
 		let issuance_manager = IssuanceManager {};
 		CredentialGateway {
+			bitcoind_client: bitcoind_client,
 			genesis_hash: genesis_block(Network::Testnet).header.block_hash(),
 			default_config: GatewayConfig::default(),
 			secp_ctx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,3 +106,4 @@ pub mod peerhandler;
 pub mod clienthandler;
 pub mod config;
 pub mod util;
+pub mod bitcoind_client;


### PR DESCRIPTION
Scarce asset verification for staking credentials need access to either the Bitcoin blockchain and SPV-style payment verification or Lightning node invoice backup. 