### PR TITLE
Send back deliverance result from `CredentialGateway`

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -16,6 +16,8 @@ use nostr::{Event, EventId, SubscriptionId};
 
 use tokio::sync::oneshot;
 
+use staking_credentials::common::msgs::{CredentialAuthenticationPayload, CredentialAuthenticationResult, ServiceDeliveranceRequest, ServiceDeliveranceResult};
+
 #[derive(Debug)]
 pub enum ClientEvents {
 	TextNote { event: Event },


### PR DESCRIPTION
After more thinking, we’ll introduce credentials as nostr tags inside event kind 3250, 3251 and 3252.