### PR TITLE
Fix ci deb issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,17 +56,18 @@ jobs:
       run: |
           apt-get update
           apt-get install -y curl gcc protobuf-compiler libsqlite3-dev pkg-config libssl-dev
-    - name: Set environment variables for pkg-config and OpenSSL
     
+    - name: Set environment variables for OpenSSL
       run: |
-          echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
-          echo "OPENSSL_DIR=/usr/include/openssl" >> $GITHUB_ENV
+          echo "OPENSSL_DIR=/usr" >> $GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu" >> $GITHUB_ENV
 
     - name: Install Rust Toolchain (stable)
       shell: bash
       run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
     -  uses: Swatinem/rust-cache@v2
     - name: Build civkit-cli
       run: cargo build --bin civkit-cli --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,12 @@ jobs:
     - name: Install dependencies
       run: |
           apt-get update
-          apt-get install -y curl gcc protobuf-compiler libsqlite3-dev
+          apt-get install -y curl gcc protobuf-compiler libsqlite3-dev pkg-config libssl-dev
+    - name: Set environment variables for pkg-config and OpenSSL
+    
+      run: |
+          echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
+          echo "OPENSSL_DIR=/usr/include/openssl" >> $GITHUB_ENV
 
     - name: Install Rust Toolchain (stable)
       shell: bash


### PR DESCRIPTION
Debian had a recurring error with libssl-dev is not installed and openssl-sys cant be retrieved. Different systems have different paths so we will see this sometimes.

Added specific paths for the failing deps. It should make this step a bit more reliable.

