### PR TITLE
Generate inclusion proofs from civkit-cli

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -82,7 +82,7 @@ enum Command {
 	CheckChainState,
 	/// Generate a merkle block (header + merkle branch) for the target txid
 	GenerateTxInclusionProof {
-		txid: Vec<u8>,
+		txid: String,
 	}
 }
 
@@ -215,10 +215,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		}
 		Command::GenerateTxInclusionProof { txid } => {
 			let request = tonic::Request::new(GenerateTxInclusionProofRequest {
-				txid: txid.to_vec(),
+				txid: txid
 			});
 
-			let _response = client.generate_tx_inclusion_proof(request).await?;
+			if let Ok(response) = client.generate_tx_inclusion_proof(request).await {
+				println!("tx inclusion proof: {}", response.into_inner().merkle_block);
+			}
 		}
 	}
 	Ok(())

--- a/src/proto/adminctrl.proto
+++ b/src/proto/adminctrl.proto
@@ -137,8 +137,9 @@ message CheckChainStateReply {
 }
 
 message GenerateTxInclusionProofRequest {
-	bytes txid = 1;
+	string txid = 1;
 }
 
 message GenerateTxInclusionProofReply {
+	string merkle_block = 1;
 }

--- a/src/rpcclient.rs
+++ b/src/rpcclient.rs
@@ -10,6 +10,7 @@
 /// Simple utilities to query bitcoin RPC API. Inspired by the bitcoin-rpc
 /// crate.
 
+
 use jsonrpc;
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
@@ -34,6 +35,7 @@ pub enum Error {
 	Json(serde_json::error::Error),
 }
 
+
 pub struct Client {
 	client: jsonrpc::client::Client,
 }
@@ -49,7 +51,7 @@ impl Client {
 		} else { return Err(Error::InvalidUserPass) }
 	}
 
-	pub fn call(&self, cmd: &str, args: &[serde_json::Value]) -> Result<(), ()> {
+	pub fn call(&self, cmd: &str, args: &[serde_json::Value]) -> Result<jsonrpc::Response, ()> {
 	
 		if let Ok(raw_args) = args.iter().map(|a| {
 			let json_string = serde_json::to_string(a)?;
@@ -60,11 +62,12 @@ impl Client {
 
 			println!("req {:?}", req);
 		
-			let resp = self.client.send_request(req);
-
-			println!("resp {:?}", resp);
+			if let Ok(resp) = self.client.send_request(req) {
+				//println!("resp {:?}", resp);
+				return Ok(resp);
+			}
 		}
 
-		Ok(())
+		Err(())
 	}
 }


### PR DESCRIPTION
One can directly use the bitcoin-cli, though this what should feed by submitcredentialproof.