### PR TITLE
Sign and generate CredentialAuthenticationResult event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ lightning-net-tokio = { git = "https://github.com/civkit/rust-lightning.git", br
 lightning-invoice = { git = "https://github.com/civkit/rust-lightning.git", branch = "civkit-branch" }
 tokio = { version = "1", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
 tokio-tungstenite = "0.19.0"
-bitcoin = "0.29.0"
+bitcoin = { version = "0.29.0", features = ["rand"] }
 bitcoin_hashes = { version = "0.11", default-features = false }
 tonic = "0.9"
 prost = "0.11"

--- a/src/bitcoind_client.rs
+++ b/src/bitcoind_client.rs
@@ -155,6 +155,7 @@ impl BitcoindHandler {
 									let hex_string = serialize(&merkle_block).to_hex();
 									let proof_json = serde_json::Value::String(hex_string);
 
+									//TODO: verify transaction paid the correct amount to the correct scrippubkey and deliver credential in function ?
 									if let Ok(response) = self.rpc_client.call("verifytxoutproof", &[proof_json]) {
 										println!("got an answer {:?}", response);
 										if let Some(raw_value) = response.result {


### PR DESCRIPTION
Still have to flow the event generated back to `civkit-sample` and get it stored in `CredentialsHolder`.