### PR TITLE
Add basic steps to get past missing mainstay/bitcoin core errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ cargo build
 cd target/debug
 #run commands above like ./civkitd
 ```
+You may run into an error like this 
+
+```
+thread 'main' panicked at src/server.rs:374:35:
+Could not deserialize the config file content: Error { inner: ErrorInner { kind: Custom, line: Some(16), col: 0, at: Some(228), message: "missing field `mainstay`", key: [] } }
+```
+
+You can resolve this by creating mainstay in example-config.toml. The values can be found in ```config.rs```
+
+```
+[mainstay]
+url = "https://mainstay.xyz/api/v1"
+position = 1
+token = "dummy_token"
+base_pubkey = "dummy_pubkey"
+chain_code = "dummy_chaincode"
+```
+
+You will also need to add bitcoin connection parameters. Currently, only clearnet nodes work via RPC.
+
+```
+[bitcoind_params]
+host = my_bitcoin_host"  # Replace with the actual host address
+port = "8332"  # usually 8332 but worth checking
+rpc_user = "my_username"   # Replace with the actual RPC username
+rpc_password = "my_password"  # Replace with the actual RPC password
+```
+
 
 Tagline
 -------


### PR DESCRIPTION
I noticed when I run ./civkitd the main branch was panicking without these variables being set. I also specified the lack of tor support, though this is an active issue to be worked on. It feels like this clears up a common error I experienced working with the code and could be helpful for future users so i added it to the readme.