### PR TITLE
add docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /target/
 Cargo.lock
 debug.log
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,7 @@ FROM ubuntu:latest
 RUN apt-get update && apt-get install -y libsqlite3-0 libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
 
 # Copy the binaries from the builder stage
-COPY --from=builder /usr/src/civkit-node/target/debug/civkitd /usr/local/bin/civkitd
-COPY --from=builder /usr/src/civkit-node/target/debug/civkit-cli /usr/local/bin/civkit-cli
-COPY --from=builder /usr/src/civkit-node/target/debug/civkit-sample /usr/local/bin/civkit-sample
+COPY --from=builder /usr/src/civkit-node/target/release/civkitd /usr/local/bin/civkitd
 
 # Expose ports
 EXPOSE 50031

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Stage 1: Building the binary
+FROM rust:latest as builder
+
+# Install protobuf compiler
+RUN apt-get update && apt-get install -y protobuf-compiler
+
+# Set the working directory in the Docker image
+WORKDIR /usr/src/civkit-node
+
+# Copy the source code into the Docker image
+COPY . .
+
+# Build the application
+RUN cargo build
+
+# Stage 2: Setup the runtime environment
+FROM ubuntu:latest
+
+# Install runtime dependencies
+# Including CA certificates
+RUN apt-get update && apt-get install -y libsqlite3-0 libssl-dev ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Copy the binaries from the builder stage
+COPY --from=builder /usr/src/civkit-node/target/debug/civkitd /usr/local/bin/civkitd
+COPY --from=builder /usr/src/civkit-node/target/debug/civkit-cli /usr/local/bin/civkit-cli
+COPY --from=builder /usr/src/civkit-node/target/debug/civkit-sample /usr/local/bin/civkit-sample
+
+# Set the default command to run the main binary
+CMD ["civkitd"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /usr/src/civkit-node
 COPY . .
 
 # Build the application
-RUN cargo build
+RUN cargo build --release --bin=civkitd
 
 # Stage 2: Setup the runtime environment
 FROM ubuntu:latest
@@ -24,6 +24,12 @@ RUN apt-get update && apt-get install -y libsqlite3-0 libssl-dev ca-certificates
 COPY --from=builder /usr/src/civkit-node/target/debug/civkitd /usr/local/bin/civkitd
 COPY --from=builder /usr/src/civkit-node/target/debug/civkit-cli /usr/local/bin/civkit-cli
 COPY --from=builder /usr/src/civkit-node/target/debug/civkit-sample /usr/local/bin/civkit-sample
+
+# Expose ports
+EXPOSE 50031
+EXPOSE 9735
+EXPOSE 50021
+EXPOSE 18443
 
 # Set the default command to run the main binary
 CMD ["civkitd"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ cargo build
 cd target/debug
 #run commands above like ./civkitd
 ```
+Docker Build
+------------
+
+```
+docker build -t civkit-node . 
+docker run --rm civkit-node
+```
 
 Tagline
 -------

--- a/debug.log
+++ b/debug.log
@@ -1,4 +1,4 @@
-10:25:07 [ INFO] Logging initialized. Log file located at: "/home/daven/./civkit-node/debug.log"
-10:25:07 [ERROR] This is a test error message
-10:25:07 [ WARN] This is a test warning message
-10:25:07 [ INFO] This is a test info message
+09:36:28 [ INFO] Logging initialized. Log file located at: "/home/daven/./civkit-node/debug.log"
+09:36:28 [ERROR] This is a test error message
+09:36:28 [ WARN] This is a test warning message
+09:36:28 [ INFO] This is a test info message

--- a/debug.log
+++ b/debug.log
@@ -1,4 +1,0 @@
-09:36:28 [ INFO] Logging initialized. Log file located at: "civkit-node/debug.log"
-09:36:28 [ERROR] This is a test error message
-09:36:28 [ WARN] This is a test warning message
-09:36:28 [ INFO] This is a test info message

--- a/debug.log
+++ b/debug.log
@@ -1,4 +1,4 @@
-09:36:28 [ INFO] Logging initialized. Log file located at: "/home/daven/./civkit-node/debug.log"
+09:36:28 [ INFO] Logging initialized. Log file located at: "civkit-node/debug.log"
 09:36:28 [ERROR] This is a test error message
 09:36:28 [ WARN] This is a test warning message
 09:36:28 [ INFO] This is a test info message

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,3 +103,4 @@ impl Default for Config {
         }
     }
 }
+


### PR DESCRIPTION
created barebones dockerfile to get node running. changed logging to fail gracefully is terminal is not available (like in a docker container) but logs still saved to debug file and display in docker. 

it can easily be run and built. 

`docker build -t civkit-node .`
` docker run --rm civkit-node`